### PR TITLE
CTCP-2359: Update Test Support API to use the EIS wrapped XML

### DIFF
--- a/app/v2/controllers/TestMessagesController.scala
+++ b/app/v2/controllers/TestMessagesController.scala
@@ -40,7 +40,7 @@ import v2.controllers.actions.ValidateMessageTypeActionProvider
 import v2.models.request.MessageRequest
 
 import javax.inject.Inject
-import scala.concurrent.ExecutionContext.Implicits._
+import scala.concurrent.ExecutionContext
 
 @ImplementedBy(classOf[TestMessagesController])
 trait V2TestMessagesController {
@@ -57,7 +57,8 @@ class TestMessagesController @Inject()(
   messageRequestAction: MessageRequestAction,
   validateDepartureMessageTypeActionProvider: ValidateMessageTypeActionProvider,
   msgGenService: MessageGenerationService
-) extends BackendController(cc)
+)(implicit ec: ExecutionContext)
+    extends BackendController(cc)
     with ResponseHelper
     with ErrorTranslator
     with V2TestMessagesController {

--- a/app/v2/models/XMLMessage.scala
+++ b/app/v2/models/XMLMessage.scala
@@ -16,10 +16,46 @@
 
 package v2.models
 
+import scala.annotation.tailrec
+import scala.xml.Elem
+import scala.xml.Node
 import scala.xml.NodeSeq
+import scala.xml.TopScope
+
+object XMLMessage {
+
+  lazy val targetPrefix = "txd"
+
+  private def resetElem(elem: Elem, prefix: String = null): Elem =
+    elem.copy(prefix = prefix, scope = TopScope, child = resetNamespaceBindings(elem.child))
+
+  private def resetElemNamespaceBindings(nodes: NodeSeq): NodeSeq = nodes match {
+    case x: Elem => resetElem(x, targetPrefix)
+    case _       => throw new IllegalArgumentException("The supplied node is not an Elem")
+  }
+
+  private def resetNamespaceBindings(nodes: Seq[Node]): Seq[Node] = {
+
+    @tailrec
+    def accumulate(nodes: Seq[Node], acc: Seq[Node]): Seq[Node] = nodes.headOption match {
+      case Some(head: Elem) => accumulate(nodes.tail, acc :+ resetElem(head))
+      case Some(head)       => accumulate(nodes.tail, acc :+ head)
+      case None             => acc
+    }
+
+    accumulate(nodes, Seq.empty)
+  }
+}
 
 case class XMLMessage(value: NodeSeq) extends AnyVal {
-  def wrapped: WrappedXMLMessage = WrappedXMLMessage(<TraderChannelResponse>{value}</TraderChannelResponse>)
+
+  def wrapped: WrappedXMLMessage = {
+    val inside = XMLMessage.resetElemNamespaceBindings(value)
+    WrappedXMLMessage(<n1:TraderChannelResponse xmlns:txd="http://ncts.dgtaxud.ec"
+                                                xmlns:n1="http://www.hmrc.gov.uk/eis/ncts5/v1"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                xsi:schemaLocation="http://www.hmrc.gov.uk/eis/ncts5/v1 EIS_WrapperV10_TraderChannelSubmission-51.8.xsd">{inside}</n1:TraderChannelResponse>)
+  }
 }
 
 case class WrappedXMLMessage(value: NodeSeq) extends AnyVal

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -3,24 +3,27 @@ import sbt._
 
 object AppDependencies {
 
+  private val bootstrapVersion  = "7.13.0"
+  private val scalaCheckVersion = "1.17.0"
+
   val compile = Seq(
-    "uk.gov.hmrc"       %% "bootstrap-backend-play-28" % "7.12.0",
-    "org.scalacheck"    %% "scalacheck"                % "1.15.4",
-    "org.typelevel"     %% "cats-core"                 % "2.7.0",
-    "io.chrisdavenport" %% "cats-scalacheck"           % "0.3.0"
+    "uk.gov.hmrc"       %% "bootstrap-backend-play-28" % bootstrapVersion,
+    "org.scalacheck"    %% "scalacheck"                % scalaCheckVersion,
+    "org.typelevel"     %% "cats-core"                 % "2.9.0",
+    "io.chrisdavenport" %% "cats-scalacheck"           % "0.3.2"
   )
 
   val test = Seq(
-    "org.mockito"             % "mockito-core"         % "4.2.0",
-    "org.scalatest"          %% "scalatest"            % "3.2.10",
-    "com.typesafe.play"      %% "play-test"            % current,
-    "org.scalatestplus.play" %% "scalatestplus-play"   % "4.0.3",
-    "org.scalatestplus"      %% "mockito-3-2"          % "3.1.2.0",
-    "org.scalacheck"         %% "scalacheck"           % "1.15.4",
-    "com.github.tomakehurst"  % "wiremock-standalone"  % "2.27.2",
-    "org.typelevel"          %% "cats-laws"            % "2.7.0",
-    "org.typelevel"          %% "discipline-core"      % "1.4.0",
-    "org.typelevel"          %% "discipline-scalatest" % "2.1.5",
-    "com.vladsch.flexmark"    % "flexmark-all"         % "0.62.2"
+    "org.mockito"             % "mockito-core"           % "4.2.0",
+    "org.scalatest"          %% "scalatest"              % "3.2.10",
+    "com.typesafe.play"      %% "play-test"              % current,
+    "org.scalatestplus.play" %% "scalatestplus-play"     % "4.0.3",
+    "org.scalatestplus"      %% "mockito-3-2"            % "3.1.2.0",
+    "org.scalacheck"         %% "scalacheck"             % scalaCheckVersion,
+    "com.github.tomakehurst"  % "wiremock-standalone"    % "2.27.2",
+    "org.typelevel"          %% "cats-laws"              % "2.7.0",
+    "org.typelevel"          %% "discipline-core"        % "1.4.0",
+    "org.typelevel"          %% "discipline-scalatest"   % "2.1.5",
+    "com.vladsch.flexmark"    % "flexmark-all"           % "0.62.2"
   ).map(_ % "test, it")
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,9 +2,9 @@ resolvers += "HMRC-open-artefacts-maven" at "https://open.artefacts.tax.service.
 
 resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.8.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.9.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.1.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.2.0")
 
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.18")
 

--- a/test/v2/models/XMLMessageSpec.scala
+++ b/test/v2/models/XMLMessageSpec.scala
@@ -20,21 +20,41 @@ import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
 
 import scala.xml.Utility.trim
+import scala.xml.XML
 
 class XMLMessageSpec extends AnyFreeSpec with Matchers {
 
-  "XMLMessage#wrapped should get a wrapped message" in {
-    val node     = <message>
-      <test>1</test> <test2>2</test2>
-    </message>
-    val expected = <TraderChannelResponse>
-      <message>
-        <test>1</test> <test2>2</test2>
-      </message>
-    </TraderChannelResponse>
-    val sut      = XMLMessage(node)
-    val result   = sut.wrapped
+  "XMLMessage#wrapped" - {
+    "should get a wrapped message" in {
+      val node     = """<ncts:message xmlns:ncts="http://ncts.dgtaxud.ec"><test>1</test><test2>2</test2></ncts:message>"""
+      val expected = <n1:TraderChannelResponse xmlns:txd="http://ncts.dgtaxud.ec"
+                                               xmlns:n1="http://www.hmrc.gov.uk/eis/ncts5/v1"
+                                               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                               xsi:schemaLocation="http://www.hmrc.gov.uk/eis/ncts5/v1 EIS_WrapperV10_TraderChannelSubmission-51.8.xsd">
+        <txd:message>
+          <test>1</test> <test2>2</test2>
+        </txd:message>
+      </n1:TraderChannelResponse>
+      val sut      = XMLMessage(XML.loadString(node))
+      val result   = sut.wrapped
 
-    trim(result.value.head) mustBe trim(expected)
+      trim(result.value.head) mustBe trim(expected)
+    }
+
+    "should get a wrapped message if a node is blank" in {
+      val node     = """<ncts:message xmlns:ncts="http://ncts.dgtaxud.ec"><test></test><test2>2</test2></ncts:message>"""
+      val expected = <n1:TraderChannelResponse xmlns:txd="http://ncts.dgtaxud.ec"
+                                               xmlns:n1="http://www.hmrc.gov.uk/eis/ncts5/v1"
+                                               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                               xsi:schemaLocation="http://www.hmrc.gov.uk/eis/ncts5/v1 EIS_WrapperV10_TraderChannelSubmission-51.8.xsd">
+        <txd:message>
+          <test></test> <test2>2</test2>
+        </txd:message>
+      </n1:TraderChannelResponse>
+      val sut      = XMLMessage(XML.loadString(node))
+      val result   = sut.wrapped
+
+      trim(result.value.head) mustBe trim(expected)
+    }
   }
 }

--- a/test/v2/services/InboundRouterServiceSpec.scala
+++ b/test/v2/services/InboundRouterServiceSpec.scala
@@ -58,9 +58,10 @@ class InboundRouterServiceSpec extends SpecBase with ModelGenerators {
     "when posting a message, should succeed and respond with the message Id" in {
       val inboundRouterConnector = mock[InboundRouterConnector]
       val response               = HttpResponse(CREATED, "Created", Map(MessageIdHeaderKey -> Seq("3")))
-      val wrappedMessage         = <TraderChannelResponse><msg></msg></TraderChannelResponse>
+      val wrappedXMLMessage      = XMLMessage(<msg></msg>).wrapped
 
-      when(inboundRouterConnector.post(any[MessageType], WrappedXMLMessage(eqTo(wrappedMessage)), any[String].asInstanceOf[CorrelationId])(any(), any()))
+      when(
+        inboundRouterConnector.post(any[MessageType], WrappedXMLMessage(eqTo(wrappedXMLMessage.value)), any[String].asInstanceOf[CorrelationId])(any(), any()))
         .thenReturn(Future.successful[HttpResponse](response))
 
       val inboundRouterService = new InboundRouterServiceImpl(inboundRouterConnector)
@@ -77,9 +78,10 @@ class InboundRouterServiceSpec extends SpecBase with ModelGenerators {
     "when posting a message, should fail if location header missing" in {
       val inboundRouterConnector = mock[InboundRouterConnector]
       val response               = HttpResponse(CREATED, "Created")
-      val wrappedXMLMessage      = <TraderChannelResponse><msg></msg></TraderChannelResponse>
+      val wrappedXMLMessage      = XMLMessage(<msg></msg>).wrapped
 
-      when(inboundRouterConnector.post(any[MessageType], WrappedXMLMessage(eqTo(wrappedXMLMessage)), any[String].asInstanceOf[CorrelationId])(any(), any()))
+      when(
+        inboundRouterConnector.post(any[MessageType], WrappedXMLMessage(eqTo(wrappedXMLMessage.value)), any[String].asInstanceOf[CorrelationId])(any(), any()))
         .thenReturn(Future.successful[HttpResponse](response))
 
       val inboundRouterService = new InboundRouterServiceImpl(inboundRouterConnector)
@@ -100,9 +102,10 @@ class InboundRouterServiceSpec extends SpecBase with ModelGenerators {
     "when posting a message, should fail if connector cannot complete its write" in {
       val inboundRouterConnector = mock[InboundRouterConnector]
       val response               = HttpResponse(INTERNAL_SERVER_ERROR, "Error")
-      val wrappedXMLMessage      = <TraderChannelResponse><msg></msg></TraderChannelResponse>
+      val wrappedXMLMessage      = XMLMessage(<msg></msg>).wrapped
 
-      when(inboundRouterConnector.post(any[MessageType], WrappedXMLMessage(eqTo(wrappedXMLMessage)), any[String].asInstanceOf[CorrelationId])(any(), any()))
+      when(
+        inboundRouterConnector.post(any[MessageType], WrappedXMLMessage(eqTo(wrappedXMLMessage.value)), any[String].asInstanceOf[CorrelationId])(any(), any()))
         .thenReturn(Future.successful[HttpResponse](response))
 
       val inboundRouterService = new InboundRouterServiceImpl(inboundRouterConnector)


### PR DESCRIPTION
Converts our `<ncts:...>` XML to EIS wrapped XML -- `<n1:TraderChannelResponse...><txd:...>`