### PR TITLE
CTCP-3822: Deprecate the test support API

### DIFF
--- a/resources/public/api/definition.json
+++ b/resources/public/api/definition.json
@@ -14,7 +14,7 @@
     "versions": [
       {
         "version": "2.0",
-        "status": "DEPRECATED",
+        "status": "RETIRED",
         "endpointsEnabled": false,
         "access": {
           "type": "PUBLIC"

--- a/resources/public/api/definition.json
+++ b/resources/public/api/definition.json
@@ -14,8 +14,8 @@
     "versions": [
       {
         "version": "2.0",
-        "status": "BETA",
-        "endpointsEnabled": true,
+        "status": "DEPRECATED",
+        "endpointsEnabled": false,
         "access": {
           "type": "PUBLIC"
         }


### PR DESCRIPTION
To be used only on TT, so will remain in a branch. This will allow an orderly withdrawal from ET.